### PR TITLE
Fix Swift 3.1 renamed type Generator

### DIFF
--- a/src/ios/SocketIOClientSwift/SocketIOClientConfiguration.swift
+++ b/src/ios/SocketIOClientSwift/SocketIOClientConfiguration.swift
@@ -25,7 +25,7 @@
 public struct SocketIOClientConfiguration : ExpressibleByArrayLiteral, Collection, MutableCollection {
     public typealias Element = SocketIOClientOption
     public typealias Index = Array<SocketIOClientOption>.Index
-    public typealias Generator = Array<SocketIOClientOption>.Generator
+    public typealias Generator = Array<SocketIOClientOption>.Iterator
     public typealias SubSequence =  Array<SocketIOClientOption>.SubSequence
     
     private var backingArray = [SocketIOClientOption]()


### PR DESCRIPTION
Builds were failing after updating Swift today. So replacing `Generator` with `Iterator` as it's been renamed in Swift 3.1 fixed this issue.

I haven't tested it with older versions of Swift.
