### PR TITLE
Add fix for Cordova 7.0 in afterPrepareHook

### DIFF
--- a/scripts/lib/swiftHelper.js
+++ b/scripts/lib/swiftHelper.js
@@ -72,20 +72,49 @@ function init(ctx) {
  * @return {Object} projectFile - project file information
  */
 function loadProjectFile() {
-  var platform_ios,
-    projectFile;
-
   try {
-    // try pre-5.0 cordova structure
-    platform_ios = context.requireCordovaModule('cordova-lib/src/plugman/platforms')['ios'];
-    projectFile = platform_ios.parseProjectFile(iosPlatformPath);
-  } catch (e) {
-    // let's try cordova 5.0 structure
-    platform_ios = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
-    projectFile = platform_ios.parseProjectFile(iosPlatformPath);
+    return loadProjectFile_cordova_7_and_above();
+  } catch(e) {
+  }
+  
+  try {
+    return loadProjectFile_cordova_5_and_6();
+  } catch(e) {
   }
 
-  return projectFile;
+  try {
+    return loadProjectFile_cordova_pre_5();
+  } catch (e) {
+  }
+
+  throw new Error('Failed to load iOS project file. Maybe your Cordova version is not supported?');
+}
+
+function loadProjectFile_cordova_pre_5() {
+  var platformIos = context.requireCordovaModule('cordova-lib/src/plugman/platforms')['ios'];
+
+  return platformIos.parseProjectFile(iosPlatformPath);
+}
+
+function loadProjectFile_cordova_5_and_6() {
+  var platformIos = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
+  
+  return platformIos.parseProjectFile(iosPlatformPath);
+}
+
+function loadProjectFile_cordova_7_and_above() {
+  var pbxPath = path.join(iosPlatformPath, projectName + '.xcodeproj', 'project.pbxproj');
+  var xcodeproj = context.requireCordovaModule('xcode').project(pbxPath);
+  xcodeproj.parseSync();
+
+  var saveProj = function() {
+    fs.writeFileSync(pbxPath, xcodeproj.writeSync());
+  };
+
+  return {
+    xcode: xcodeproj,
+    write: saveProj
+  };
 }
 
 /**


### PR DESCRIPTION
closes #22 

- adapted from https://github.com/nordnet/cordova-hot-code-push/blob/master/scripts/lib/iosWKWebViewEngineSupport.js
- changes verified with Cordova v7.0.1